### PR TITLE
Organization repos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Usage
 
 ::
 
-    usage: gts [-h] username [repo] [save_csv]
+    usage: gts [-h] username [repo] [save_csv] [-o]
 
     positional arguments:
       username    Github username
@@ -46,6 +46,7 @@ Usage
 
     optional arguments:
       -h, --help  show this help message and exit
+      -o, --organization specify Github organization if different from username
 
 Run
 ---

--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,10 @@ Run on the command line with either ``python`` or ``python3``.
     $ # Or to get stats on all of your repositories
     $ gts 'nchah' 'ALL' 'save_csv'
     Password:* (passwords are hidden)
+    
+    $ # Or if you are running on an organization repo (for example NREL's SAM repo) as a user with access
+    $ gts 'nickdiorio' 'SAM' 'save_csv' -o 'NREL'
+    Password:* (passwords are hidden)
     ...
 
 Traffic data stored in CSV files with columns:

--- a/gts/main.py
+++ b/gts/main.py
@@ -216,16 +216,17 @@ def store_csv(file_path, repo, json_response, response_type):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('organization', help='Github organization')
     parser.add_argument('username', help='Github username')
     parser.add_argument('repo', help='User\'s repo', default='ALL', nargs='?')
     parser.add_argument('save_csv', default='save_csv', help='Set to "no_csv" if no CSV should be saved', nargs='?')
+    parser.add_argument('-o', '--organization', default=None, help='Github organization')
     args = parser.parse_args()
     """ Run main code logic
-    :param organization: string - GitHub organization (frequently username)
     :param username: string - GitHub username
     :param repo: string - GitHub user's repo name or by default 'ALL' repos
     :param save_csv: string - Specify if CSV log should be saved
+    :optional:
+	param -o, --organization: string - GitHub organization (if different from username)
     """
     organization = args.organization.strip()
     username = args.username.strip()

--- a/gts/main.py
+++ b/gts/main.py
@@ -222,6 +222,7 @@ def main():
     parser.add_argument('save_csv', default='save_csv', help='Set to "no_csv" if no CSV should be saved', nargs='?')
     args = parser.parse_args()
     """ Run main code logic
+    :param organization: string - GitHub organization (frequently username)
     :param username: string - GitHub username
     :param repo: string - GitHub user's repo name or by default 'ALL' repos
     :param save_csv: string - Specify if CSV log should be saved
@@ -235,7 +236,7 @@ def main():
 
     if repo == 'ALL':
         # By default iterate over all repositories
-        repos_response = send_request('repos', auth_pair).json()
+        repos_response = send_request('repos', organization, auth_pair).json()
         # Error handling in case of {'documentation_url': 'https://developer.github.com/v3', 'message': 'Not Found'}
         try:
             if repos_response.get('message'):
@@ -246,11 +247,11 @@ def main():
             for repo in repos_response:
                 repos.append(repo['name'])
             for repo in repos:
-                traffic_response = send_request('traffic', auth_pair, repo, traffic_headers).json()
+                traffic_response = send_request('traffic', organization, auth_pair, repo, traffic_headers).json()
                 print(json_to_table(repo, traffic_response, 'traffic'))
-                clones_response = send_request('clones', auth_pair, repo, traffic_headers).json()
+                clones_response = send_request('clones', organization, auth_pair, repo, traffic_headers).json()
                 print(json_to_table(repo, clones_response, 'clones'))
-                referrers_response = send_request('referrers', auth_pair, repo, traffic_headers).json()
+                referrers_response = send_request('referrers', organization, auth_pair, repo, traffic_headers).json()
                 print(json_to_table_referrers(repo, referrers_response))
                 # Saving data
                 if args.save_csv == 'save_csv':
@@ -265,9 +266,9 @@ def main():
             print(traffic_response['message'])
             return 'Code done.'
         print(json_to_table(repo, traffic_response, 'traffic'))
-        clones_response = send_request('clones', auth_pair, repo, traffic_headers).json()
+        clones_response = send_request('clones', organization, auth_pair, repo, traffic_headers).json()
         print(json_to_table(repo, clones_response, 'clones'))
-        referrers_response = send_request('referrers', auth_pair, repo, traffic_headers).json()
+        referrers_response = send_request('referrers', organization, auth_pair, repo, traffic_headers).json()
         print(json_to_table_referrers(repo, referrers_response))
         # Saving data
         if args.save_csv == 'save_csv':

--- a/gts/main.py
+++ b/gts/main.py
@@ -228,9 +228,12 @@ def main():
     :optional:
 	param -o, --organization: string - GitHub organization (if different from username)
     """
-    organization = args.organization.strip()
     username = args.username.strip()
     repo = args.repo.strip()
+    organization = username
+    if args.organization != None:
+        organization = args.organization.strip()
+
     pw = getpass.getpass('Password:')
     auth_pair = (username, pw)
     traffic_headers = {'Accept': 'application/vnd.github.spiderman-preview'}


### PR DESCRIPTION
The existing implementation implicitly assumes that the username is the same as the organization which owns the repository, but this isn't always the case.  As an example, corporate, government, or other organizations often have their own GitHub organization which result in repo names like:

`https://github.com/NREL/SAM`

Where NREL is an organization with many users.  For these repo's, supplying a username/password is not enough, since the existing implementation would create:

`https://github.com/nickdiorio/SAM`

For my username as an example.  This pull request adds the flexibility to specify an organization in addition to the username/password, i.e:

`python main.py 'NREL' 'nickdiorio' 'SAM' 'save_csv'`

When the organization and username are the same, my implementation would require:

`python main.py 'nickdiorio' 'nickdiorio' 'github-traffic-stats' 'save_csv' `

Which could perhaps be made more elegant by making the `organization` input default to `username`.

Hope this helps, happy to revamp if desired.



