### PR TITLE
Add support for username:password pairs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,8 +51,7 @@ Usage
       -h, --help  show this help message and exit
       -o, --organization specify Github organization if different from username
        
-    Information on Github Access Tokens:
-      https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
+    Information on `tokens`_.
 
 Run
 ---
@@ -130,3 +129,4 @@ A list of the references used for this project.
 .. _libraries: https://developer.github.com/libraries/
 .. _GitHub API: https://developer.github.com/v3/
 .. _Preview the Repository Traffic API (August 15, 2016): https://developer.github.com/changes/2016-08-15-traffic-api-preview/
+.. _Github Access Tokens: https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/

--- a/README.rst
+++ b/README.rst
@@ -38,15 +38,21 @@ Usage
 ::
 
     usage: gts [-h] username [repo] [save_csv] [-o]
+       or: 
+    usage: gts [-h] username:password [repo] [save_csv] [-o]
 
     positional arguments:
       username    Github username
+      password    Github password for 'username', or access token
       repo        User's repo
       save_csv    Set to "no_csv" if no CSV should be saved
 
     optional arguments:
       -h, --help  show this help message and exit
       -o, --organization specify Github organization if different from username
+       
+    Information on Github Access Tokens:
+      https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
 
 Run
 ---

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Usage
       -h, --help  show this help message and exit
       -o, --organization specify Github organization if different from username
        
-    Information on `tokens`_.
+Information on `tokens`_ .
 
 Run
 ---

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Usage
       -h, --help  show this help message and exit
       -o, --organization specify Github organization if different from username
        
-Information on `tokens`_ .
+Information on `Github Access Tokens`_ .
 
 Run
 ---
@@ -130,3 +130,4 @@ A list of the references used for this project.
 .. _GitHub API: https://developer.github.com/v3/
 .. _Preview the Repository Traffic API (August 15, 2016): https://developer.github.com/changes/2016-08-15-traffic-api-preview/
 .. _Github Access Tokens: https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
+

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Usage
       -h, --help  show this help message and exit
       -o, --organization specify Github organization if different from username
        
-Information on `Github Access Tokens`_ .
+Information on `Github Access Tokens`_.
 
 Run
 ---

--- a/gts/main.py
+++ b/gts/main.py
@@ -21,7 +21,7 @@ def send_request(resource, organization, auth, repo=None, headers=None):
     """ Send request to specific Github API endpoint
     :param resource: string - specify the API to call
     :param organization: string - specify the repository organization if not owner by username
-    :param auth: tuple - username-password tuple
+    :param auth: username:password separated string - if no password specified, interactive dialog used
     :param repo: string - if specified, the specific repository name
     :param headers: dict - if specified, the request headers
     :return: response - GET request response
@@ -222,19 +222,28 @@ def main():
     parser.add_argument('-o', '--organization', default=None, help='Github organization')
     args = parser.parse_args()
     """ Run main code logic
-    :param username: string - GitHub username
+    :param username: string - GitHub username, or username:password pair
     :param repo: string - GitHub user's repo name or by default 'ALL' repos
     :param save_csv: string - Specify if CSV log should be saved
     :optional:
 	param -o, --organization: string - GitHub organization (if different from username)
     """
-    username = args.username.strip()
+
+    str = args.username.strip()
+    sub = str.split(':', 1 )
+    len_sub = len(sub)
+
+    username = sub[0].strip()
+    if len_sub > 1:
+        pw = sub[1].strip()
+    else :
+        pw = getpass.getpass('Password:')
+
     repo = args.repo.strip()
     organization = username
     if args.organization != None:
         organization = args.organization.strip()
 
-    pw = getpass.getpass('Password:')
     auth_pair = (username, pw)
     traffic_headers = {'Accept': 'application/vnd.github.spiderman-preview'}
 


### PR DESCRIPTION
This Pull adds support to specify username:password for authentication. 

If only username is specified (eg no ``:password``), then the interactive dialog will be called as per the original usage. 

The password can be ``usernames`` Github account password, or a Github Access Token, which is documented at:
  https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
