### PR TITLE
Changes handling of psycopg2 as a requirement

### DIFF
--- a/gts/main.py
+++ b/gts/main.py
@@ -6,7 +6,6 @@ import os
 from collections import OrderedDict
 import datetime
 import getpass
-import psycopg2
 import requests
 
 
@@ -239,6 +238,15 @@ def store_db(db_config={}, repo='', json_response='', response_type=''):
    :param json_response: json - the json input
    :param response_type: str - 'views', 'clones', ''
    """
+   
+   try:
+      import psycopg2
+   except:
+      import sys
+      sys.stderr.write('The psycopg2 library is required to use database features.\n')
+      sys.stderr.flush()
+      sys.exit(1)
+
    # Connect to database 
    conn = psycopg2.connect(host=db_config['host'], port=db_config['port'], user=db_config['user'], password=db_config['password'], dbname=db_config['dbname']) 
    conn.autocommit = True

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,9 @@ setup(
     install_requires=[
         'requests'
     ],
+    extras_require = {
+        'sql':  ["psycopg2"]
+    }
     classifiers=[
         'Intended Audience :: Developers',
     ],


### PR DESCRIPTION
I added psycopg2 as an extra instead of a requirement. I did not remove it from requirements.txt.

I also moved the import of psycopg2 into the only function where it was used. This way the program can run without having to install the psycopg2. This is a good thing because if someone is not needing the database features like myself it is one less thing to clutter up a users site-packages folder.