### PR TITLE
fix: setup.py build process failed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     ],
     extras_require = {
         'sql':  ["psycopg2"]
-    }
+    },
     classifiers=[
         'Intended Audience :: Developers',
     ],


### PR DESCRIPTION
As title says - if you try cloning the repo and pip installing this project, it fails because a missing comma.